### PR TITLE
link to roadmaps should point to package, not core, roadmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Requests to include new collections into the `ansible` package.
 
 We use GitHub's Discussion feature to track these requests.
 
-Deadlines for the `ansible` package can be found in the [`ansible` roadmaps](https://docs.ansible.com/ansible-core/devel/roadmap/ansible_core_roadmap_index.html)
+Deadlines for the `ansible` package can be found in the [`ansible` roadmaps](https://docs.ansible.com/ansible/devel/roadmap/ansible_roadmap_index.html)
 
 ## Existing request
 


### PR DESCRIPTION
##### SUMMARY
Updates the link in the README.md. The old link took users to the ansible-core Roadmaps, which have no information about getting collections included in the Ansible package. The new link takes users to the Ansible Roadmaps.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
README.md

##### ADDITIONAL INFORMATION
Came up in the Ansible Community meeting today. See https://meetbot.fedoraproject.org/ansible-community/2022-02-02/ansible_community_meeting.2022-02-02-18.00.log.html. 